### PR TITLE
Update Description of Auction Item

### DIFF
--- a/lib/renaissance/auctions/auctions.ex
+++ b/lib/renaissance/auctions/auctions.ex
@@ -1,5 +1,5 @@
 defmodule Renaissance.Auctions do
-  import Ecto.Query
+  import Ecto.{Query, Changeset}
   alias Renaissance.{Repo, Auction}
 
   def create_auction(user_id, params) do
@@ -16,6 +16,13 @@ defmodule Renaissance.Auctions do
       |> Map.put("seller_id", user_id)
 
     Repo.insert(Auction.changeset(%Auction{}, details))
+  end
+
+  def update_description(auction_id, params) do
+    Auction
+    |> Repo.get!(auction_id)
+    |> change(description: params["description"])
+    |> Repo.update()
   end
 
   def get(id) do

--- a/lib/renaissance_web/controllers/auction_controller.ex
+++ b/lib/renaissance_web/controllers/auction_controller.ex
@@ -51,7 +51,7 @@ defmodule RenaissanceWeb.AuctionController do
     end
   end
 
-  def update_description(conn, params) do
+  def update(conn, params) do
     id = String.to_integer(params["id"])
     response = Auctions.update_description(id, params)
 

--- a/lib/renaissance_web/controllers/auction_controller.ex
+++ b/lib/renaissance_web/controllers/auction_controller.ex
@@ -53,20 +53,16 @@ defmodule RenaissanceWeb.AuctionController do
 
   def update(conn, params) do
     id = String.to_integer(params["id"])
-    response = Auctions.update_description(id, params)
-
-    case response do
-      {:ok, _auction} ->
-        conn
-        |> put_flash(:info, "Auction Updated!")
-        |> render("show.html", %{
-          auction: Auctions.get(id),
-          user: Auth.current_user(conn),
-          changeset: conn
-        })
-
-      {:error, changeset} ->
-        render(conn, "show.html", changeset: changeset)
+    with {:ok, _auctions} <- Auctions.update_description(id, params) do
+      conn
+      |> put_flash(:info, "Auction Updated!")
+      |> render("show.html", %{
+        auction: Auctions.get(id),
+        user: Auth.current_user(conn),
+        changeset: conn
+      })
+    else
+      {:error, changeset} -> render(conn, "show.html", changeset: changeset)
     end
   end
 end

--- a/lib/renaissance_web/controllers/auction_controller.ex
+++ b/lib/renaissance_web/controllers/auction_controller.ex
@@ -40,9 +40,33 @@ defmodule RenaissanceWeb.AuctionController do
   def show(conn, %{"id" => id}) do
     if Auth.signed_in?(conn) do
       {id, _} = Integer.parse(id)
-      render(conn, "show.html", %{auction: Auctions.get(id)})
+
+      render(conn, "show.html", %{
+        auction: Auctions.get(id),
+        user: Auth.current_user(conn),
+        changeset: conn
+      })
     else
       redirect(conn, to: Routes.login_path(conn, :login))
+    end
+  end
+
+  def update_description(conn, params) do
+    id = String.to_integer(params["id"])
+    response = Auctions.update_description(id, params)
+
+    case response do
+      {:ok, _auction} ->
+        conn
+        |> put_flash(:info, "Auction Updated!")
+        |> render("show.html", %{
+          auction: Auctions.get(id),
+          user: Auth.current_user(conn),
+          changeset: conn
+        })
+
+      {:error, changeset} ->
+        render(conn, "show.html", changeset: changeset)
     end
   end
 end

--- a/lib/renaissance_web/helpers/auth.ex
+++ b/lib/renaissance_web/helpers/auth.ex
@@ -12,9 +12,7 @@ defmodule RenaissanceWeb.Helpers.Auth do
     |> return_user()
   end
 
-  defp return_user(nil) do
-    nil
-  end
+  defp return_user(nil), do: nil
 
   defp return_user(id) do
     Users.get(id)

--- a/lib/renaissance_web/helpers/auth.ex
+++ b/lib/renaissance_web/helpers/auth.ex
@@ -1,7 +1,19 @@
 defmodule RenaissanceWeb.Helpers.Auth do
+  alias Renaissance.Users
+
   def signed_in?(conn) do
     current_user_id = Plug.Conn.get_session(conn, :current_user_id)
 
     current_user_id != nil
+  end
+
+  def current_user(conn) do
+    case Plug.Conn.get_session(conn, :current_user_id) do
+      nil ->
+        nil
+
+      id ->
+        Users.get(id)
+    end
   end
 end

--- a/lib/renaissance_web/helpers/auth.ex
+++ b/lib/renaissance_web/helpers/auth.ex
@@ -8,12 +8,15 @@ defmodule RenaissanceWeb.Helpers.Auth do
   end
 
   def current_user(conn) do
-    case Plug.Conn.get_session(conn, :current_user_id) do
-      nil ->
-        nil
+    Plug.Conn.get_session(conn, :current_user_id)
+    |> return_user()
+  end
 
-      id ->
-        Users.get(id)
-    end
+  defp return_user(nil) do
+    nil
+  end
+
+  defp return_user(id) do
+    Users.get(id)
   end
 end

--- a/lib/renaissance_web/router.ex
+++ b/lib/renaissance_web/router.ex
@@ -22,9 +22,7 @@ defmodule RenaissanceWeb.Router do
     get "/login", LoginController, :login
     post "/login", LoginController, :verify
 
-    post "/auctions/:id/update_description", AuctionController, :update_description
-
     resources "/register", RegisterController, only: [:new, :create]
-    resources "/auctions", AuctionController, only: [:index, :create, :new, :show]
+    resources "/auctions", AuctionController, only: [:index, :create, :new, :show, :update]
   end
 end

--- a/lib/renaissance_web/router.ex
+++ b/lib/renaissance_web/router.ex
@@ -22,6 +22,8 @@ defmodule RenaissanceWeb.Router do
     get "/login", LoginController, :login
     post "/login", LoginController, :verify
 
+    post "/auctions/:id/update_description", AuctionController, :update_description
+
     resources "/register", RegisterController, only: [:new, :create]
     resources "/auctions", AuctionController, only: [:index, :create, :new, :show]
   end

--- a/lib/renaissance_web/templates/auction/show.html.eex
+++ b/lib/renaissance_web/templates/auction/show.html.eex
@@ -5,7 +5,7 @@
       <%= if @user.email != @auction.seller.email do %>
         <i><%= @auction.description %></i>
       <% else %>
-        <%= form_for @changeset, Routes.auction_path(@conn, :update_description, @auction), fn f -> %>
+        <%= form_for @changeset, Routes.auction_path(@conn, :update, @auction), [method: :put], fn f -> %>
           <%= text_input f, :description, class: "txt-form",
           value: @auction.description, required: true %>
           <%= error_tag f, :description %>

--- a/lib/renaissance_web/templates/auction/show.html.eex
+++ b/lib/renaissance_web/templates/auction/show.html.eex
@@ -2,7 +2,19 @@
   <div class="pageGroup show-auction">
     <h1 class="lbl-group"><%= @auction.title %></h1>
     <div class="content-text show-auction">
-      <i><%= @auction.description %></i>
+      <%= if @user.email != @auction.seller.email do %>
+        <i><%= @auction.description %></i>
+      <% else %>
+        <%= form_for @changeset, Routes.auction_path(@conn, :update_description, @auction), fn f -> %>
+          <%= text_input f, :description, class: "txt-form",
+          value: @auction.description, required: true %>
+          <%= error_tag f, :description %>
+
+          <div class="form-section">
+          <%= submit "Update Auction" %>
+          </div>
+        <% end %>
+      <% end %>
       <div class="centered-container">
         <table class="item-table">
           <tr class="table-row"><td class="table-section table-left">Price:</td><td class="bold table-section table-right"><%= @auction.price %></td></tr>

--- a/test/renaissance/auctions/auctions_test.exs
+++ b/test/renaissance/auctions/auctions_test.exs
@@ -78,5 +78,18 @@ defmodule Renaissance.Test.AuctionsTest do
       assert second.description == @auction_two["description"]
       assert second.price == Money.new(15_00)
     end
+
+    test "updates a pre-existing auction description" do
+      seller_id = fixture(:user).id
+      {:ok, auction} = Auctions.create_auction(seller_id, @auction_one)
+
+      auction_id = auction.id
+      updated_description = "Updated"
+
+      Auctions.update_description(auction_id, %{"description" => updated_description})
+
+      retrieved_auction = Auctions.get(auction_id)
+      assert retrieved_auction.description == updated_description
+    end
   end
 end

--- a/test/renaissance_web/controllers/auction_controller_test.exs
+++ b/test/renaissance_web/controllers/auction_controller_test.exs
@@ -107,5 +107,30 @@ defmodule RenaissanceWeb.AuctionControllerTest do
         get(conn, "/auctions/0")
       end
     end
+
+    test "GET /auctions/:id when the user is the seller the description is edittable", %{
+      conn: conn
+    } do
+      conn = conn |> post("/auctions", @auction_one_params)
+      auction_one_id = Repo.get_by(Auction, title: @auction_one_params.title).id
+      conn = get(conn, "/auctions/#{auction_one_id}")
+
+      assert html_response(conn, 200) =~
+               ~s(type="text" value="#{@auction_one_params.description}")
+    end
+
+    test "POST /auction/:id/update_description", %{conn: conn} do
+      conn = conn |> post("/auctions", @auction_one_params)
+      auction_id = Repo.get_by(Auction, title: @auction_one_params.title).id
+      conn = get(conn, "/auctions/#{auction_id}")
+
+      updated_description = "Updated " <> @auction_one_params.description
+
+      conn =
+        conn
+        |> post("/auctions/#{auction_id}/update_description", %{description: updated_description})
+
+      assert get_flash(conn, :info) == "Auction Updated!"
+    end
   end
 end

--- a/test/renaissance_web/controllers/auction_controller_test.exs
+++ b/test/renaissance_web/controllers/auction_controller_test.exs
@@ -119,7 +119,7 @@ defmodule RenaissanceWeb.AuctionControllerTest do
                ~s(type="text" value="#{@auction_one_params.description}")
     end
 
-    test "POST /auction/:id/update_description", %{conn: conn} do
+    test "PUT /auction/:id/update", %{conn: conn} do
       conn = conn |> post("/auctions", @auction_one_params)
       auction_id = Repo.get_by(Auction, title: @auction_one_params.title).id
       conn = get(conn, "/auctions/#{auction_id}")
@@ -128,7 +128,7 @@ defmodule RenaissanceWeb.AuctionControllerTest do
 
       conn =
         conn
-        |> post("/auctions/#{auction_id}/update_description", %{description: updated_description})
+        |> put("/auctions/#{auction_id}", %{description: updated_description})
 
       assert get_flash(conn, :info) == "Auction Updated!"
     end


### PR DESCRIPTION
Part one of two to enable the seller of an item to update the title and description of their auction after it has started.