### PR TITLE
Update Title of Auction Item

### DIFF
--- a/lib/renaissance/auctions/auctions.ex
+++ b/lib/renaissance/auctions/auctions.ex
@@ -18,10 +18,15 @@ defmodule Renaissance.Auctions do
     Repo.insert(Auction.changeset(%Auction{}, details))
   end
 
-  def update_description(auction_id, params) do
-    Auction
-    |> Repo.get!(auction_id)
-    |> change(description: params["description"])
+  def update_auction(auction_id, params) do
+    auction =
+      Auction
+      |> Repo.get!(auction_id)
+
+    change(auction, %{
+      description: params["description"] || auction.description,
+      title: params["title"] || auction.title
+    })
     |> Repo.update()
   end
 

--- a/lib/renaissance_web/controllers/auction_controller.ex
+++ b/lib/renaissance_web/controllers/auction_controller.ex
@@ -53,7 +53,8 @@ defmodule RenaissanceWeb.AuctionController do
 
   def update(conn, params) do
     id = String.to_integer(params["id"])
-    with {:ok, _auctions} <- Auctions.update_description(id, params) do
+
+    with {:ok, _auctions} <- Auctions.update_auction(id, params) do
       conn
       |> put_flash(:info, "Auction Updated!")
       |> render("show.html", %{

--- a/lib/renaissance_web/router.ex
+++ b/lib/renaissance_web/router.ex
@@ -22,6 +22,8 @@ defmodule RenaissanceWeb.Router do
     get "/login", LoginController, :login
     post "/login", LoginController, :verify
 
+    post "/auctions/:id/update_description", AuctionController, :update_description
+
     resources "/register", RegisterController, only: [:new, :create]
     resources "/auctions", AuctionController, only: [:index, :create, :new, :show, :update]
   end

--- a/lib/renaissance_web/router.ex
+++ b/lib/renaissance_web/router.ex
@@ -22,8 +22,6 @@ defmodule RenaissanceWeb.Router do
     get "/login", LoginController, :login
     post "/login", LoginController, :verify
 
-    post "/auctions/:id/update_description", AuctionController, :update_description
-
     resources "/register", RegisterController, only: [:new, :create]
     resources "/auctions", AuctionController, only: [:index, :create, :new, :show, :update]
   end

--- a/lib/renaissance_web/templates/auction/show.html.eex
+++ b/lib/renaissance_web/templates/auction/show.html.eex
@@ -1,11 +1,15 @@
 <div class="pageContent">
   <div class="pageGroup show-auction">
-    <h1 class="lbl-group"><%= @auction.title %></h1>
-    <div class="content-text show-auction">
       <%= if @user.email != @auction.seller.email do %>
+        <h1 class="lbl-group"><%= @auction.title %></h1>
+        <div class="content-text show-auction">
         <i><%= @auction.description %></i>
       <% else %>
         <%= form_for @changeset, Routes.auction_path(@conn, :update, @auction), [method: :put], fn f -> %>
+        <%= text_input f, :title, class: "lbl-group",
+        value: @auction.title, required: true %>
+        <%= error_tag f, :title %>
+        <div class="content-text show-auction">
           <%= text_input f, :description, class: "txt-form",
           value: @auction.description, required: true %>
           <%= error_tag f, :description %>

--- a/test/renaissance/auctions/auctions_test.exs
+++ b/test/renaissance/auctions/auctions_test.exs
@@ -84,12 +84,25 @@ defmodule Renaissance.Test.AuctionsTest do
       {:ok, auction} = Auctions.create_auction(seller_id, @auction_one)
 
       auction_id = auction.id
-      updated_description = "Updated"
+      updated_description = "Updated Description"
 
-      Auctions.update_description(auction_id, %{"description" => updated_description})
+      Auctions.update_auction(auction_id, %{"description" => updated_description})
 
       retrieved_auction = Auctions.get(auction_id)
       assert retrieved_auction.description == updated_description
+    end
+
+    test "updates a pre-existing auction title" do
+      seller_id = fixture(:user).id
+      {:ok, auction} = Auctions.create_auction(seller_id, @auction_one)
+
+      auction_id = auction.id
+      updated_title = "Updated Title"
+
+      Auctions.update_auction(auction_id, %{"title" => updated_title})
+
+      retrieved_auction = Auctions.get(auction_id)
+      assert retrieved_auction.title == updated_title
     end
   end
 end

--- a/test/renaissance_web/controllers/auction_controller_test.exs
+++ b/test/renaissance_web/controllers/auction_controller_test.exs
@@ -108,7 +108,7 @@ defmodule RenaissanceWeb.AuctionControllerTest do
       end
     end
 
-    test "GET /auctions/:id when the user is the seller the description is edittable", %{
+    test "GET /auctions/:id when the user is the seller the description is editable", %{
       conn: conn
     } do
       conn = conn |> post("/auctions", @auction_one_params)
@@ -119,7 +119,7 @@ defmodule RenaissanceWeb.AuctionControllerTest do
                ~s(type="text" value="#{@auction_one_params.description}")
     end
 
-    test "PUT /auction/:id/update", %{conn: conn} do
+    test "PUT /auction/:id for description", %{conn: conn} do
       conn = conn |> post("/auctions", @auction_one_params)
       auction_id = Repo.get_by(Auction, title: @auction_one_params.title).id
       conn = get(conn, "/auctions/#{auction_id}")
@@ -129,6 +129,31 @@ defmodule RenaissanceWeb.AuctionControllerTest do
       conn =
         conn
         |> put("/auctions/#{auction_id}", %{description: updated_description})
+
+      assert get_flash(conn, :info) == "Auction Updated!"
+    end
+
+    test "GET /auctions/:id when the user is the seller the title is editable", %{
+      conn: conn
+    } do
+      conn = conn |> post("/auctions", @auction_one_params)
+      auction_one_id = Repo.get_by(Auction, title: @auction_one_params.title).id
+      conn = get(conn, "/auctions/#{auction_one_id}")
+
+      assert html_response(conn, 200) =~
+               ~s(type="text" value="#{@auction_one_params.title}")
+    end
+
+    test "PUT /auction/:id for title", %{conn: conn} do
+      conn = conn |> post("/auctions", @auction_one_params)
+      auction_id = Repo.get_by(Auction, title: @auction_one_params.title).id
+      conn = get(conn, "/auctions/#{auction_id}")
+
+      updated_title = "Updated " <> @auction_one_params.title
+
+      conn =
+        conn
+        |> put("/auctions/#{auction_id}", %{title: updated_title})
 
       assert get_flash(conn, :info) == "Auction Updated!"
     end


### PR DESCRIPTION
Part two of two to enable the seller of an item to update the title and description of their auction after it has started.